### PR TITLE
23 refactor the greatest increase in profits

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,13 @@
 <html lang="en-gb">
 <head>
   <meta charset="UTF-8">
+
+  <!-- SEO meta -->
+  <meta name="description" content="Bootcamp challenge Console Finances App">
+  <meta name="keywords" content="HTML, CSS, JavaScript">
+  <meta name="author" content="Technoveltyco">
+  <!-- end SEO meta -->
+
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Console Finances App // Bootcamp Week 4 Challenge</title>

--- a/main.js
+++ b/main.js
@@ -1,10 +1,10 @@
 ///
-// Dataset declaration.
+// Dataset initialization.
 ///
 const dataset = (typeof finances !== 'undefined') ? finances : [];
 
 ///
-// Function declarations. 
+// Functions declarations. 
 ///
 
 /**
@@ -177,6 +177,9 @@ function getGreatestDecrease() {
 
 /**
  * Main entry point.
+ * 
+ * @returns {String}
+ *      The Financial Analysis output.
  */
 function financialAnalysis() {
     const totalMonths = getTotalMonths();
@@ -208,5 +211,8 @@ function financialAnalysis() {
 // Executes main entry point. 
 ///
 
+// Gets financial analysis output.
 const output = financialAnalysis();
+
+// Logs output to the console.
 console.log(output);

--- a/main.js
+++ b/main.js
@@ -146,15 +146,13 @@ function getAverageChange() {
  *      The transaction (date and amount) with the greatest amount.
  */
 function getGreatestIncrease() {
-    const amounts = dataset.map(function (transaction) {
-       return transaction[1]; 
-    });
-    const maxAmount = Math.max(...amounts);
-    const transaction = dataset.find(function(transaction) {
-        return transaction[1] === maxAmount;
-    });
+    const rateOfChanges = getRateOfChanges();
+    const maxRoCAmount = Math.max(...rateOfChanges);
+
+    const index = rateOfChanges.indexOf(maxRoCAmount) + 1; // Add 1 to get the present transaction of the period.
+    const [presentDatePeriod, presentBalancePeriod] = getTransaction(index);
     
-    return transaction;
+    return [presentDatePeriod, maxRoCAmount];
 }
 
 /**


### PR DESCRIPTION
* Update code comments.
* Add SEO meta tags.
* Fix the greatest increase in profits calculation.
* Updates `getGreatestIncrease()` to use the rate of changes returned by `getRateOfChanges()`.
* FInal output:

```
    Financial Analysis
------------------------------------------------------------------------
    Total Months: 86
    Total: $38,382,578.00
    Average Change: -$2,315.12
    Greatest Increase in Profits: Feb-2012 ($1,926,159.00)
    Greatest Decrease in Profits: Sep-2013 (-$1,196,225.00)
------------------------------------------------------------------------
```
